### PR TITLE
fix alias default behavior

### DIFF
--- a/clerc
+++ b/clerc
@@ -6,7 +6,7 @@
 #* home:    https://github.com/micharbet/CLE
 #* version: 2018-10-01 (Zodiac)
 #* license: GNU GPL v2
-#* Copyright (C) 2016-2018 by Michael Arbet 
+#* Copyright (C) 2016-2018 by Michael Arbet
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -133,7 +133,7 @@ cat <<EOT
   |     |     __|    ...bit of life to the command line
   |     |     |      Learn more:$_CL cle help$_CN and$_CL cle doc$_CN
  \____|_____|_____|  Uncover the magic:$_CL less $CLE_RC$_CN
- 
+
 EOT
 }
 
@@ -188,7 +188,7 @@ _clesc () (
 _setp () {
 	local CC I CI C
 	C=${1:-$CLE_CLR}
-	case "$C" in 
+	case "$C" in
 	red)	CC=RrR;;
 	green)	CC=GgG;;
 	yellow)	CC=YyY;;
@@ -201,7 +201,7 @@ _setp () {
 	???)	CC=$C;; # any 3 colors
 	*)	# print help on colors
 		printb "Unknown color '$CLE_CLR' Select predefined scheme:"
-		declare -f _setp|sed -n 's/\(\<[a-z |]*\)).*/\1/p' 
+		declare -f _setp|sed -n 's/\(\<[a-z |]*\)).*/\1/p'
 		echo Alternatively create your own 3-letter combo using rgbcmykw/RGBCMYKW
 		echo E.g. cle color rgB
 		return 1
@@ -304,21 +304,22 @@ cx () { cd $_XX; }
 aa () {
 	local AED=$CLE_AL.ed
 	case "$1" in
-	"")	## `aa`         - show aliases
+	"")	## `aa`           - show aliases
                 builtin alias|sed "s/^alias \(.*\)='\(.*\)'/$_CL\1$_CN	\2/";;
-	-s)	## `aa -s`      - save aliases
+	-s)	## `aa -s`        - save aliases
 		builtin alias >$CLE_AL;;
-	-e)	## `aa -e`      - edit aliases
+	-e)	## `aa -e`        - edit aliases
 		builtin alias >$AED
 		vi $AED
 		builtin unalias -a
 		. $AED;;
-	*=*)	## `aa a='b'`   - create new alias and save
+	*=*)	## `aa a='b'`     - create new alias and save
 		builtin alias "$*"
 		aa -s;;
-	-h)	## `aa -h`      - show this help
+	-h)	## `aa -h`        - show this help
 		cle help aa;;
-	*)	builtin alias "$*";;
+	*)	## `aa aliasname` - show definition of alias aliasthatexists
+		builtin alias "$*";;
 	esac
 }
 
@@ -474,7 +475,7 @@ cat <<-EOS
 	bindkey "^[[1;5D" prev
 	bindkey "^[[1;5C" next
 	defscrollback 9000
-	hardstatus alwayslastline 
+	hardstatus alwayslastline
 	hardstatus string '%{= Kk}%-w%{+u KC}%n %t%{-}%+w %-=%{KG}$CLE_SHN%{Kg} %c'
 	bind c screen $CLE_RC
 	bind ^c screen $CLE_RC
@@ -502,7 +503,7 @@ _compcle () {
 complete -F _compcle cle
 
 declare -F _known_hosts >/dev/null && complete -F _known_hosts lssh
-_C=/usr/share/bash-completion/completions/ssh 
+_C=/usr/share/bash-completion/completions/ssh
 if [ -f $_C ]; then
 	. $_C
 	complete -F _ssh lssh

--- a/clerc
+++ b/clerc
@@ -287,7 +287,6 @@ fi
 # Remove alias 'which' if there is no version supporting extended options
 { alias|command which -i which || unalias which; } >/dev/null 2>&1
 
-unalias .. ... xx cx >/dev/null 2>&1 # transition
 
 ## ** cd command additions **
 ## `.. ...`     - up one or two levels
@@ -317,8 +316,9 @@ aa () {
 	*=*)	## `aa a='b'`   - create new alias and save
 		builtin alias "$*"
 		aa -s;;
-	*)	cle help aa
-		return 1
+	-h)	## `aa -h`      - show this help
+		cle help aa;;
+	*)	builtin alias "$*";;
 	esac
 }
 

--- a/clerc.sh
+++ b/clerc.sh
@@ -417,8 +417,9 @@ aa () {
 	*=*)	## `aa a='b'`   - create new alias and save
 		builtin alias "$*"
 		aa -s;;
-	*)	cle help aa
-		return 1
+	-h)	## `aa -h`      - show this help
+		cle help aa;;
+	*)	builtin alias "$*";;
 	esac
 }
 

--- a/clerc.sh
+++ b/clerc.sh
@@ -6,7 +6,7 @@
 #* home:    https://github.com/micharbet/CLE
 #* version: 2018-10-01 (Zodiac)
 #* license: GNU GPL v2
-#* Copyright (C) 2016-2018 by Michael Arbet 
+#* Copyright (C) 2016-2018 by Michael Arbet
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -197,7 +197,7 @@ cat <<EOT
   |     |     __|    ...bit of life to the command line
   |     |     |      Learn more:$_CL cle help$_CN and$_CL cle doc$_CN
  \____|_____|_____|  Uncover the magic:$_CL less $CLE_RC$_CN
- 
+
 EOT
 }
 
@@ -257,7 +257,7 @@ _clesc () (
 _setp () {
 	local CC I CI C
 	C=${1:-$CLE_CLR}
-	case "$C" in 
+	case "$C" in
 	red)	CC=RrR;;
 	green)	CC=GgG;;
 	yellow)	CC=YyY;;
@@ -270,7 +270,7 @@ _setp () {
 	???)	CC=$C;; # any 3 colors
 	*)	# print help on colors
 		printb "Unknown color '$CLE_CLR' Select predefined scheme:"
-		declare -f _setp|sed -n 's/\(\<[a-z |]*\)).*/\1/p' 
+		declare -f _setp|sed -n 's/\(\<[a-z |]*\)).*/\1/p'
 		echo Alternatively create your own 3-letter combo using rgbcmykw/RGBCMYKW
 		echo E.g. cle color rgB
 		return 1
@@ -379,7 +379,7 @@ fi
 # Remove alias 'which' if there is no version supporting extended options
 #: This weird construction ensures the 'which' will work even in case an
 #: aliased version with extended options (e.g. --read-alias on Fedora) was
-#: defined on workstation and copied to remote session  
+#: defined on workstation and copied to remote session
 { alias|command which -i which || unalias which; } >/dev/null 2>&1
 
 #: transition - remove aliases defined in previous versions
@@ -404,22 +404,23 @@ cx () { cd $_XX; }
 aa () {
 	local AED=$CLE_AL.ed
 	case "$1" in
-	"")	## `aa`         - show aliases
+	"")	## `aa`           - show aliases
 		#: also meke the output nicer and more easy to read
                 builtin alias|sed "s/^alias \(.*\)='\(.*\)'/$_CL\1$_CN	\2/";;
-	-s)	## `aa -s`      - save aliases
+	-s)	## `aa -s`        - save aliases
 		builtin alias >$CLE_AL;;
-	-e)	## `aa -e`      - edit aliases
+	-e)	## `aa -e`        - edit aliases
 		builtin alias >$AED
 		vi $AED
 		builtin unalias -a
 		. $AED;;
-	*=*)	## `aa a='b'`   - create new alias and save
+	*=*)	## `aa a='b'`     - create new alias and save
 		builtin alias "$*"
 		aa -s;;
-	-h)	## `aa -h`      - show this help
+	-h)	## `aa -h`        - show this help
 		cle help aa;;
-	*)	builtin alias "$*";;
+	*)	## `aa aliasname` - show definition of alias aliasthatexists
+		builtin alias "$*";;
 	esac
 }
 
@@ -509,7 +510,7 @@ _rhlog () {
 #: grab *active* resource file, tweak file, pack it to tarball and store
 #: into variable C64 as base64 encoded string.
 #: Argument ($1) may contain additional suffix to filenames
-#: Second outcome of _clepak is value in $RC - relative path to the resource 
+#: Second outcome of _clepak is value in $RC - relative path to the resource
 #: file that should be run on remote system (it may contain the suffix)
 #: Note: configuration is not packed in order to ensure unique cf on all
 #:  remote accounts.
@@ -568,7 +569,7 @@ lsudo () (
 )
 
 ## `lsu [user]`        - su wrapper
-#: known issue - on debian systems controlling terminal is detached in case 
+#: known issue - on debian systems controlling terminal is detached in case
 #: a command ($CLE_RC) is specified, use 'lsudo' instead
 lsu () (
 	S=
@@ -641,7 +642,7 @@ cat <<-EOS
 	bindkey "^[[1;5D" prev
 	bindkey "^[[1;5C" next
 	defscrollback 9000
-	hardstatus alwayslastline 
+	hardstatus alwayslastline
 	hardstatus string '%{= Kk}%-w%{+u KC}%n %t%{-}%+w %-=%{KG}$CLE_SHN%{Kg} %c'
 	bind c screen $CLE_RC
 	bind ^c screen $CLE_RC
@@ -679,7 +680,7 @@ complete -F _compcle cle
 declare -F _known_hosts >/dev/null && complete -F _known_hosts lssh
 #: while _ssh is better
 #: The path is valid at least on fedora and debian with installed bash-completion package
-_C=/usr/share/bash-completion/completions/ssh 
+_C=/usr/share/bash-completion/completions/ssh
 if [ -f $_C ]; then
 	. $_C
 	complete -F _ssh lssh
@@ -740,7 +741,7 @@ EOT
 #: 'cle something'. This is how modularity has been implemented.
 #: That means you can replace parts of code or enhance 'cle' command by
 #: defining your own '_cle_something' bash functions
-#: 
+#:
 cle () {
 	local C I MM BRC NC
 	C=$1;shift


### PR DESCRIPTION
This patch will add possibility to show definition of alias by running e.g. 'aa ls'.

Signed-off-by: Matej Dujava <mdujava@redhat.com>