### PR TITLE
Fixed 2 bugs

### DIFF
--- a/clerc
+++ b/clerc
@@ -4,7 +4,7 @@
 ##
 #* author:  Michael Arbet (marbet@redhat.com)
 #* home:    https://github.com/micharbet/CLE
-#* version: 2019-08-09 (Zodiac)
+#* version: 2019-08-19 (Zodiac)
 #* license: GNU GPL v2
 #* Copyright (C) 2016-2019 by Michael Arbet
 
@@ -592,7 +592,7 @@ _clepak () {
 		echo "# evironment $CLE_USER@$CLE_FHN" >$EN
 		vdump "CLE_SRE|CLE_P..|_C." >>$EN
 		vdump "$CLE_EXP" >>$EN
-		cat $CLE_AL >>$EN
+		cat $CLE_AL >>$EN 2>/dev/null
 	fi
 	[ $1 ] && C64=`eval tar chzf - $RC $TW $EN 2>/dev/null | base64 | tr -d '\n\r '`
 }

--- a/clerc.sh
+++ b/clerc.sh
@@ -4,7 +4,7 @@
 ##
 #* author:  Michael Arbet (marbet@redhat.com)
 #* home:    https://github.com/micharbet/CLE
-#* version: 2019-08-09 (Zodiac)
+#* version: 2019-08-19 (Zodiac)
 #* license: GNU GPL v2
 #* Copyright (C) 2016-2019 by Michael Arbet
 
@@ -736,7 +736,7 @@ _clepak () {
 		vdump "CLE_SRE|CLE_P..|_C." >>$EN
 		vdump "$CLE_EXP" >>$EN
 		echo "CLE_DEBUG='$CLE_DEBUG'" >>$EN			# dbg
-		cat $CLE_AL >>$EN
+		cat $CLE_AL >>$EN 2>/dev/null
 	fi
 	#: if tarball required, create it and save to $C64
 	#: I've never owned this computer, I had Atari 800XL :)

--- a/modules/cle-mod
+++ b/modules/cle-mod
@@ -1,7 +1,7 @@
 ##
 ## ** cle-mod: CLE module management **
 #
-#* version: 2019-03-27
+#* version: 2019-08-19
 #* author:  Michael Arbet (marbet@redhat.com)
 #* home:    https://github.com/micharbet/CLE
 #* license: GNU GPL v2
@@ -134,6 +134,7 @@ ls)	## `cle mod ls`        - list modules
 add)	## `cle mod add [mod]` - install module from repository
 	#_clemodindex || return $?
 	# get matching modules
+	_clemodindex
 	MODS=`sed -n "/[^:]*$2[^:]*/s/\([^:]*\):.*/\1/p" $INDEXFILE`
 	[ "$MODS" ] || { echo Nothing like $2 to install; return 1; }
 	MODN=`wc -w <<<$MODS`

--- a/modules/modulist
+++ b/modules/modulist
@@ -2,7 +2,7 @@ mod-git:2019-03-12:fe120e9fb29e9bd2554f4869e1548ddd:GIT helpers / shorcuts
 mod-mancolor:2018-08-29:4cb76858862d9809fd7d5ecd821ded51:Colorize man pages
 mod-fsps:2018-11-13:47a349bdd04024447d00177bbcfb7859:Filesystem and processess utilities
 cle-ed:2019-05-17:baf24c81a2cc27572803a84526c85eaf:Tweak and config editor
-cle-mod:2019-03-27:dcf2ce0c878a48f0a269fc28d402e1d5:CLE module management
 cle-prompt:2019-03-31:d27abf5272c54db1d6b8196c9b43884d:pre-configured prompt themes
 cle-rcmove:2018-09-23:c00dc60dddf2366e64cf44b36b7e208d:Move resource files to different folder
+cle-mod:2019-08-19:aeeac9f42ecc0768aadad29b24247cfd:CLE module management
 cle-palette:2019-06-29:109c28c325599e0af2ffe0411cece546:Color palettes for OSC4 capable terminals


### PR DESCRIPTION
- live session complained there was no 'al' file. error
  message suppressed
- First `cle mod add ...` failed because there was no module
  index downloaded. It was necessary to run `cle mod ls` first.
  now module index is downloaded before every 'add' operation