### PR TITLE
Update name of ssh function in bash-complation

### DIFF
--- a/clerc
+++ b/clerc
@@ -779,7 +779,7 @@ complete -F _clecomp cle
 declare -F _known_hosts >/dev/null && complete -F _known_hosts lssh
 _N=/usr/share/bash-completion
 _clexe $_N/bash_completion
-_clexe $_N/completions/ssh && complete -F _ssh lssh
+_clexe $_N/completions/ssh && complete -F _comp_cmd_ssh lssh
 
 # redefine alias builtins
 alias () {

--- a/clerc.sh
+++ b/clerc.sh
@@ -1044,11 +1044,11 @@ complete -F _clecomp cle
 # lssh completion
 #: there are two possibilities of ssh completion _known_hosts is more common...
 declare -F _known_hosts >/dev/null && complete -F _known_hosts lssh
-#: while _ssh is better
+#: while _comp_cmd_ssh is better
 #: The path is valid at least on fedora and debian with installed bash-completion package
 _N=/usr/share/bash-completion
 _clexe $_N/bash_completion
-_clexe $_N/completions/ssh && complete -F _ssh lssh
+_clexe $_N/completions/ssh && complete -F _comp_cmd_ssh lssh
 
 # redefine alias builtins
 #: those definitions must be here, only after config and tweaks not to mess


### PR DESCRIPTION
_ssh was removed in https://github.com/scop/bash-completion/commit/909fe14b0c4c96d23966bc91b4e990209ad44085#diff-ea186058eaccb2fe1f557ed71d7cf58a9220a37ed3ab7fae9d2b0c99e48029deL363