### PR TITLE
Make _clegit work in worktree and show detach commits

### DIFF
--- a/clerc
+++ b/clerc
@@ -580,9 +580,9 @@ if which git >/dev/null 2>&1; then
 		_GITC=
 		_GITB=
 		while [ "$D" != '' ]; do
-			if [ -d $D/.git ]; then
+			if [ -d $D/.git -o -f $D/.git ]; then
 				git diff-index --quiet HEAD -- || _GITC=$_Cr
-				printf -v _GITB $'\ue0a0'%s "$(git symbolic-ref --short HEAD)"
+				printf -v _GITB $'\ue0a0'%s "$(git symbolic-ref --short HEAD || git rev-parse --short HEAD)"
 			fi
 			D=${D%/*}
 		done

--- a/clerc.sh
+++ b/clerc.sh
@@ -758,10 +758,10 @@ if which git >/dev/null 2>&1; then
 		_GITC=
 		_GITB=
 		while [ "$D" != '' ]; do
-			if [ -d $D/.git ]; then
+			if [ -d $D/.git -o -f $D/.git ]; then
 				#: verify dirty status
 				git diff-index --quiet HEAD -- || _GITC=$_Cr
-				printf -v _GITB $'\ue0a0'%s "$(git symbolic-ref --short HEAD)"
+				printf -v _GITB $'\ue0a0'%s "$(git symbolic-ref --short HEAD || git rev-parse --short HEAD)"
 			fi
 			D=${D%/*}
 		done


### PR DESCRIPTION
In worktree `.git` is a file with content like `gitdir: /path/to/bare-repo/worktrees/woktree-a`.

When using detached HEAD (checkout/switch to commit or tag), now HASH will be printed, as originally nothing was printed.